### PR TITLE
Removes applicationId so app uses namespace.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,6 @@ android {
     compileSdk 32
 
     defaultConfig {
-        applicationId "com.gpeal.droidconanvilsample"
         minSdk 21
         targetSdk 32
         versionCode 1


### PR DESCRIPTION
Having separate `namespace` and `applicationId` settings can make things difficult or unexpected and isn't necessary.  The [docs recommend](https://developer.android.com/studio/build/configure-app-module) keeping them the same. This updates the app's build.gradle file to match the recommendations.